### PR TITLE
Fix initial filter button display bug

### DIFF
--- a/js/modules/ui/TableRenderer.js
+++ b/js/modules/ui/TableRenderer.js
@@ -163,6 +163,11 @@ class TableRenderer {
         // タイトルと保存ボタンのコンテナを作成
         const titleContainer = DOMHelper.createElement('div', {}, 'results-title-container');
 
+        // SearchAndFilter はヘッダー生成前にインスタンス化しておく（初回表示でのボタン初期化のため）
+        if (window.SearchAndFilter && !this.searchAndFilter) {
+            this.searchAndFilter = new window.SearchAndFilter(this);
+        }
+
         // 仮想スクロール対応のテーブルコンテナを作成
         const tableContainer = this.virtualScroll.createVirtualScrollTable(integratedData);
 
@@ -1277,6 +1282,14 @@ class TableRenderer {
     updateToggleButtonState(button) {
         if (this.searchAndFilter && typeof this.searchAndFilter.updateToggleButtonState === 'function') {
             return this.searchAndFilter.updateToggleButtonState(button);
+        }
+        // フォールバック（SearchAndFilter未生成の初回表示時など）
+        if (this.isFiltered) {
+            button.textContent = '解除';
+            button.className = 'header-clear-button';
+        } else {
+            button.textContent = '絞込';
+            button.className = 'header-filter-button';
         }
     }
 


### PR DESCRIPTION
Fixes the 1st column header filter button not reflecting its state on initial search by ensuring `SearchAndFilter` is available and adding a fallback.

The button's state was not correctly initialized on the first render because `SearchAndFilter` was not yet instantiated when `updateToggleButtonState` was called. This PR ensures `SearchAndFilter` is available earlier and provides a fallback to use the `isFiltered` state directly.

---
<a href="https://cursor.com/background-agent?bcId=bc-a375440c-1c5c-402f-a38d-56a16e45afd0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a375440c-1c5c-402f-a38d-56a16e45afd0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

